### PR TITLE
SwiftyDropbox uses AuthenticationServices like the other auth libraries

### DIFF
--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
@@ -366,17 +366,6 @@ open class MobileSharedApplication: SharedApplication {
                 session.start()
                 return
             }
-            if #available(iOS 11.0, *) {
-                let session = MobileAuthenticationSession(url: authURL) { [weak self] callbackUrl in
-                    self?.authChannel = nil
-                    if let url = callbackUrl {
-                        DropboxClientsManager.handleRedirectURL(url) { result in }
-                    }
-                }
-                self.authChannel = session
-                session.start()
-                return
-            }
         }
         
         let safariVC = MobileSafariViewController(url: authURL) { [weak self] svc, didCancel in
@@ -490,18 +479,6 @@ extension MobileWebAuthenticationSession: ASWebAuthenticationPresentationContext
     
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return self.presentingWindow ?? UIApplication.shared.windows.first { $0.isKeyWindow }!
-    }
-    
-}
-
-@available(iOS, introduced: 11.0, deprecated: 12.0)
-fileprivate class MobileAuthenticationSession: SFAuthenticationSession {
-    
-    public init(url: URL, completion: @escaping ((URL?) -> Void)) {
-        // Assume the the custom URL scheme is registered in the app's Info.plist
-        super.init(url: url, callbackURLScheme: nil) { callbackURL, error in
-            completion(callbackURL)
-        }
     }
     
 }

--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
@@ -501,7 +501,7 @@ extension MobileWebAuthenticationSession: ASWebAuthenticationPresentationContext
     
 }
 
-@available(iOS 11.0, *)
+@available(iOS, introduced: 11.0, deprecated: 12.0)
 fileprivate class MobileAuthenticationSession: SFAuthenticationSession {
     
     public init(url: URL, completion: @escaping ((URL?, Bool) -> Void)) {
@@ -523,7 +523,7 @@ open class MobileSafariViewController: SFSafariViewController, SFSafariViewContr
     public init(url: URL, dismissHandler: @escaping ((MobileSafariViewController, Bool) -> Void)) {
         self.dismissHandler = dismissHandler
         if #available(iOS 11.0, *) {
-            var configuration = SFSafariViewController.Configuration()
+            let configuration = SFSafariViewController.Configuration()
             configuration.entersReaderIfAvailable = false
             super.init(url: url, configuration: configuration)
         } else {


### PR DESCRIPTION
After upgrading AppAuth and GTMAppAuth, SwiftyDropbox was the only one left using SFSafariViewController. Apple's AuthenticationServices has better support for auth flows starting in iOS 11.

I left the old SFSafariViewController as a fallback and try to use the newer libraries when possible. The new interfaces are pretty different, since they are Sessions instead of VCs and directly give you a callbackURL with the service's response rather than Safari passing back to the app through openURL:

For some reason if you cancel out of SFSafariViewController it also does a second redirect within Notability from the cancelBlock. I guess Safari wasn't closing or something. The newer ones don't bother calling it because the app seems to run fine without the extra redirect (and on catalyst, it is opening the old Notability app I still have installed).

The Dropbox flows also don't always call out to the app's completion block, which we could change now, but I didn't want to make any other changes yet. It only calls all the way out when you cancel the SFSafariViewController flow, which is the least helpful case, and why an error message was showing up unexpectedly in the original ticket