### PR TITLE
#3118: add completion block to OAuthMobile MobileSharedApplication flow

### DIFF
--- a/SwiftyDropbox.podspec
+++ b/SwiftyDropbox.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SwiftyDropbox'
-  s.version      = '6.0.3a'
+  s.version      = '6.0.3b'
   s.summary      = 'Dropbox Swift SDK for API v2'
   s.homepage     = 'https://dropbox.com/developers/'
   s.license      = 'MIT'


### PR DESCRIPTION
## Description

CloudBridge authorizes with a completion block. All non-Dropbox services call this completion as you'd expect. On `staging`, SwiftyDropbox only calls the completion when you cancel out of the flow.

If you completed the flow, it would not call completion but since it's redirecting back from Safari the app lifecycle would lead to the Settings table getting reloaded and appearing in the correct state.

Adding the newer AuthSession stuff for catalyst support means it's not doing URL redirects anymore, so the table isn't getting reloaded after you sign in successfully. This means it looks like you're still logged out and is confusing.

This updates the SwiftyDropbox flow so that it calls the completion block in all cases after the session is done.

## Test Cases

1. Cancel the UIAlertView prompt saying you're going to be redirected to dropbox
2. Cancel from the popup window
3. Login and then deny access
4. Login and then grant access
5. Log out